### PR TITLE
Binary mask selection failing after (possible) mask shortening

### DIFF
--- a/rlscore/utilities/linalg.py
+++ b/rlscore/utilities/linalg.py
@@ -39,9 +39,10 @@ def svd_economy_sized(X):
     evecs, svals, U = la.svd(X, full_matrices=0)
     evals = np.multiply(svals, svals)
     
-    evecs = evecs[:, svals > 0]
-    svals = svals[svals > 0]
-    U = U[svals > 0]
+    nonzero_svals = svals > 0
+    evecs = evecs[:, nonzero_svals]
+    svals = svals[nonzero_svals]
+    U = U[nonzero_svals]
     return evecs, svals, U
 
 


### PR DESCRIPTION
Binary mask selection failed when some zero singular values were found. Mask was being shortened before applying it for the last time.

Swapping the lines:
```
svals = svals[svals > 0]
U = U[svals > 0]
```
may suffice, but I decided to define the `nonzero_svals` variable to avoid recomputation of the mask.